### PR TITLE
Add no-friction physics material

### DIFF
--- a/Assets/_Project/Materials/NoFriction.physicMaterial
+++ b/Assets/_Project/Materials/NoFriction.physicMaterial
@@ -1,0 +1,12 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!134 &13400000
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Name: NoFriction
+  dynamicFriction: 0
+  staticFriction: 0
+  bounciness: 0
+  frictionCombine: 0
+  bounceCombine: 0

--- a/Assets/_Project/Materials/NoFriction.physicMaterial.meta
+++ b/Assets/_Project/Materials/NoFriction.physicMaterial.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b1874e7679e4662909f5c1e49e1112f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 13400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scenes/Arena.unity
+++ b/Assets/_Project/Scenes/Arena.unity
@@ -613,7 +613,7 @@ CapsuleCollider:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 367409708}
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 13400000, guid: 7b1874e7679e4662909f5c1e49e1112f, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0


### PR DESCRIPTION
## Summary
- add `NoFriction` physics material so the player doesn't stick to walls
- reference new physics material in Arena scene

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68548f47774c8330a6aeec6d76cb497a